### PR TITLE
The ongenerate hook used by plugin execute is deprecated. The generat…

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function execute (commands) {
     }
     return {
         name: 'execute',
-        ongenerate: function () {
+        generateBundle: function () {
             var copy = commands.slice(0)
             var next = function () {
                 var command


### PR DESCRIPTION
…eBundle hook should be used instead.