### PR TITLE
feat: 🎸 Allow any rollup hook instead of `generateBundle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,19 @@ export default {
             'robocopy src public index.html',
             // Then open the browser
             'start firefox -new-window "' + path.join(process.cwd(), 'public', 'index.html') + '"'
-        ])
+        ], {
+            sync: true,
+            hooks: ['generateBundle', 'writeBundle'],
+        })
     ]
 }
 ```
+
+## Options
+
+Additionally to the scripts array, a 2nd optional object parameter is accepted. It can have the following properties:
+
+* **sync** (*optional*, defaults to `false`): set it to `true` to execute scripts in a blocking-way.
+* **hooks** (*optional*, defaults to `["generateBundle"]`): One or an array of [valid hook names](https://rollupjs.org/guide/en/#hooks) to execute scripts on. For instance, if you want to use it as an output plugin (executed at the total end of the build), use the [`"writeBundle"` hook](https://rollupjs.org/guide/en/#writebundle).
 
 Enjoy!

--- a/index.js
+++ b/index.js
@@ -2,49 +2,106 @@
 var spawn = require('child_process').spawn
 var spawnSync = require('child_process').spawnSync
 
+// List of hooks usable in rollup
+const VALID_HOOKS = [
+  'augmentChunkHash',
+  'generateBundle',
+  'outputOptions',
+  'renderChunk',
+  'renderError',
+  'renderStart',
+  'resolveDynamicImport',
+  'resolveFileUrl',
+  'writeBundle',
+];
+const DEFAULT_OPTIONS = { sync: false, hooks: ['generateBundle'] };
+// Convert & default options
+const transformOptions = options => {
+  if (options === undefined) {
+    return DEFAULT_OPTIONS;
+  } else if (typeof options !== 'object') {
+    // cast sync as boolean
+    const sync = !!options;
+    console.warn(`rollup-plugin-execute: 2nd parameter of the "execute" plugin should be an object. Please use "{sync:${sync}}" instead.`);
+    return { ...DEFAULT_OPTIONS, sync };
+  } else {
+    const sync = options.sync === true;
 
-function execute (commands, sync) {
-    if (typeof commands === 'string') {
-        commands = [commands]
-    }
-    if (!Array.isArray(commands)) {
-        throw new Error('Command(s) should be a string or an array')
-    }
-    return {
-        name: 'execute',
-        generateBundle: function () {
-            var copy = commands.slice(0)
-            var next = function () {
-                var command
-                if (!(command = copy.shift())) {
-                    return
-                }
-                
-                if ((sync !== undefined) && (sync == true)) {
-                    let ret = spawnSync(command, {
-                        shell: true,
-                        stdio: 'inherit',
-                        env: process.env
-                    })
-                    if (ret.status === 0) {
-                        next()
-                    }
-                } else {
-                    spawn(command, {
-                        shell: true,
-                        stdio: 'inherit',
-                        env: process.env
-                    }).on('close', function (code) {
-                        if (code === 0) {
-                            next()
-                        }
-                    })
-                }
-                
-            }
-            next()
+    if (typeof options.hooks === 'string') {
+      return {
+        sync,
+        hooks: [options.hooks]
+      }
+    } else if (Array.isArray(options.hooks)) {
+      const hooksValidated = options.hooks.filter(hook => {
+        if (!VALID_HOOKS.includes(hook)) {
+          console.error(`rollup-plugin-execute: Unknown or deprecated hook "${hook}". See https://rollupjs.org/guide/en/#hooks for a list of hooks you can use.`);
+          return false;
         }
+        return true;
+      });
+      // If an empty array is provided, or some hook names are invalid, throw an error.
+      if (hooksValidated.length < 1 || hooksValidated.length !== options.hooks.length) {
+        throw new TypeError('`hooks` option must be a non-empty array of valid hook names. See https://rollupjs.org/guide/en/#hooks for a list of hooks you can use.');
+      }
+      return {
+        sync,
+        hooks: hooksValidated,
+      }
+    } else if (options.hooks === undefined) {
+      return { ...DEFAULT_OPTIONS, sync };
+    } else {
+      throw new TypeError('`hooks` option is invalid. It should be either omitted, or a valid hook name, or an array of valid hook names. See https://rollupjs.org/guide/en/#hooks for a list of hooks you can use.');
     }
+  }
+}
+
+function execute(commands, options) {
+  const { sync, hooks } = transformOptions(options);
+  if (typeof commands === 'string') {
+    commands = [commands]
+  }
+  if (!Array.isArray(commands)) {
+    throw new TypeError('Command(s) should be a string or an array')
+  }
+
+  function executeHook() {
+    var copy = commands.slice(0)
+    var next = function () {
+      var command
+      if (!(command = copy.shift())) {
+        return
+      }
+
+      if (sync) {
+        let ret = spawnSync(command, {
+          shell: true,
+          stdio: 'inherit',
+          env: process.env
+        })
+        if (ret.status === 0) {
+          next()
+        }
+      } else {
+        spawn(command, {
+          shell: true,
+          stdio: 'inherit',
+          env: process.env
+        }).on('close', function (code) {
+          if (code === 0) {
+            next()
+          }
+        })
+      }
+
+    }
+    next()
+  }
+
+  return {
+    ...Object.fromEntries(hooks.map(hook => [hook, executeHook])),
+    name: 'execute',
+  };
 }
 
 module.exports = execute

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "bugs": {
     "url": "https://github.com/audinue/rollup-plugin-execute/issues"
   },
-  "homepage": "https://github.com/audinue/rollup-plugin-execute#readme"
+  "homepage": "https://github.com/audinue/rollup-plugin-execute#readme",
+  "peerDependencies": {
+    "rollup": "^1.0.0"
+  }
 }


### PR DESCRIPTION
`sync` parameter was replaced with an option object, allowing `sync` &
`hooks` properties.

BREAKING CHANGE: Deprecated `sync` truthy/falsy 2nd parameter. Use `options.sync`
instead.

Closes: #3

There are a lot of diffs, and a lot of them being just stuff moved or re-indented. The core logic remains the same.